### PR TITLE
update from React.PropTypes to the PropTypes standalone library

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "classnames": "^2.2.5",
     "deep-equal": "^1.0.1",
     "lodash.omit": "^4.5.0",
+    "prop-types": "^15.5.10",
     "swiper": "^3.4.2"
   },
   "standard": {

--- a/src/Slide.js
+++ b/src/Slide.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types';
 import omit from 'lodash.omit'
 import cx from 'classnames'
 

--- a/src/Slide.js
+++ b/src/Slide.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'
 import omit from 'lodash.omit'
 import cx from 'classnames'
 

--- a/src/Swiper.js
+++ b/src/Swiper.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes, Children } from 'react'
+import React, { Component, Children } from 'react'
+import PropTypes from 'prop-types';
 import deepEqual from 'deep-equal'
 import cx from 'classnames'
 import omit from 'lodash.omit'

--- a/src/Swiper.js
+++ b/src/Swiper.js
@@ -1,5 +1,5 @@
 import React, { Component, Children } from 'react'
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'
 import deepEqual from 'deep-equal'
 import cx from 'classnames'
 import omit from 'lodash.omit'

--- a/src/swiperEvents.js
+++ b/src/swiperEvents.js
@@ -1,4 +1,4 @@
-import { PropTypes } from 'react'
+import PropTypes from 'prop-types';
 
 export const events = [
   'onInit',

--- a/src/swiperEvents.js
+++ b/src/swiperEvents.js
@@ -1,4 +1,4 @@
-import PropTypes from 'prop-types';
+import PropTypes from 'prop-types'
 
 export const events = [
   'onInit',


### PR DESCRIPTION
As of React 15.5 PropTypes have been moved to a standalone library. This is an update to move to that library.