### PR TITLE
[WIP] add clickableBullets option

### DIFF
--- a/demo/src/Demo.js
+++ b/demo/src/Demo.js
@@ -17,8 +17,9 @@ export default class Demo extends Component {
       options: {
         navigation: true,
         pagination: true,
+        paginationClickable: true,
         scrollBar: false,
-        loop: false,
+        loop: false
       }
     }
   }

--- a/src/Swiper.js
+++ b/src/Swiper.js
@@ -70,6 +70,7 @@ export default class Swiper extends Component {
       pagination,
       scrollBar,
       onInitSwiper,
+      paginationClickable,
       loop
     } = this.props
     const opts = {}
@@ -77,7 +78,8 @@ export default class Swiper extends Component {
     if (pagination) {
       opts.pagination = opts.pagination || {}
       Object.assign(opts.pagination, {
-        el: this._pagination
+        el: this._pagination,
+        clickable: paginationClickable || false
       })
     }
     if (scrollBar) {
@@ -339,7 +341,6 @@ export default class Swiper extends Component {
           <div className={cx('swiper-wrapper', wrapperClassName)}>
             {this._getSlideChildren()}
           </div>
-
           {this._renderOptional(
             pagination,
             'swiper-pagination',


### PR DESCRIPTION
Hi @nickpisacane,

Fixes #25 

I did found the option that needs to be added to enable the clickable bullets but I'm not sure of the approach that you prefer for the API.

It seems that the only place to configure the behaviour is through the `swiperOptions` prop so that's why I put the option `clickableBullets` but the approach that iDangerous take was to set `pagination` as a [configuration object](http://idangero.us/swiper/api/#pagination).

So I want you to tell me what is the right approach for you with this inclusion :)

Thanks for your time!